### PR TITLE
Fix NPE in ScriptingData if FileWatcher was not initialized

### DIFF
--- a/src/main/java/org/cyclops/integratedscripting/core/network/ScriptingData.java
+++ b/src/main/java/org/cyclops/integratedscripting/core/network/ScriptingData.java
@@ -79,7 +79,9 @@ public class ScriptingData implements IScriptingData {
 
     public void close() {
         try {
-            this.watchService.close();
+            if (this.watchService != null) {
+                this.watchService.close();
+            }
         } catch (IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Saw this NPE during shutdown after a crash in a crashlog in a support forum.