### PR TITLE
Pre-initialize TRegex in the Graal fallback classloader

### DIFF
--- a/src/main/java/org/cyclops/integratedscripting/core/packageddependencies/PackagedDependenciesLoader.java
+++ b/src/main/java/org/cyclops/integratedscripting/core/packageddependencies/PackagedDependenciesLoader.java
@@ -70,6 +70,11 @@ public class PackagedDependenciesLoader {
             Context.Builder build = Context.newBuilder("js");
             Context con = build.build();
             con.eval("js", "console.log('graaljs has been pre-loaded.')");
+            // Force-initialize TRegex here as well.
+            // Its static loggers resolve the 'regex' language id via the thread context classloader,
+            // which only points to Graal within this block.
+            // Initializing it later (on a server thread) fails permanently for the whole JVM session.
+            con.eval("js", "/graaljs/.test('graaljs')");
             con.close();
         } finally {
             Thread.currentThread().setContextClassLoader(p);

--- a/src/main/java/org/cyclops/integratedscripting/gametest/GameTestsScripts.java
+++ b/src/main/java/org/cyclops/integratedscripting/gametest/GameTestsScripts.java
@@ -15,6 +15,7 @@ import org.cyclops.integrateddynamics.core.evaluate.operator.Operators;
 import org.cyclops.integrateddynamics.core.evaluate.variable.ValueObjectTypeItemStack;
 import org.cyclops.integrateddynamics.core.evaluate.variable.ValueTypeBoolean;
 import org.cyclops.integrateddynamics.core.evaluate.variable.ValueTypeInteger;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueTypeString;
 import org.cyclops.integrateddynamics.core.evaluate.variable.ValueTypes;
 import org.cyclops.integrateddynamics.part.PartTypePanelDisplay;
 import org.cyclops.integratedscripting.Reference;
@@ -99,6 +100,37 @@ public class GameTestsScripts {
 
         // Create constants as input to the script's function
         ItemStack variableConst1 = createVariableForValue(helper.getLevel(), ValueTypes.OBJECT_ITEMSTACK, ValueObjectTypeItemStack.ValueItemStack.of(new ItemStack(Items.APPLE, 32)));
+
+        // Insert all variables into the variable store
+        positions.variableStore().getInventory().setItem(0, variableScript);
+        positions.variableStore().getInventory().setItem(1, variableConst1);
+
+        // Create variable card for applying the function
+        ItemStack variableApplied = createVariableForOperator(helper.getLevel(), Operators.OPERATOR_APPLY, new int[]{
+                getVariableFacade(helper.getLevel(), variableScript).getId(),
+                getVariableFacade(helper.getLevel(), variableConst1).getId(),
+        });
+
+        // Place variable in display
+        Pair<PartTypePanelDisplay, PartTypePanelDisplay.State> partAndState = placeVariableInDisplayPanel(helper.getLevel(), positions.displayPanel(), variableApplied);
+
+        helper.succeedWhen(() -> {
+            assertValueEqual(partAndState.getRight().getDisplayValue(), ValueTypeBoolean.ValueBoolean.of(true));
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT)
+    public void testScriptsDisplayScriptRegex(GameTestHelper helper) {
+        GameTestHelpersIntegratedScripting.NetworkPositions positions = createBasicNetwork(helper, POS);
+
+        // Write script
+        ScriptingNetworkHelpers.getScriptingData().setScript(positions.diskId(), Path.of("script0.js"), "function abc(a) { return /^aether:.+_gloves/.test(a); }", IScriptingData.ChangeLocation.MEMORY);
+
+        // Create variable from script
+        ItemStack variableScript = createVariableForScript(helper.getLevel(), positions.diskId(), Path.of("script0.js"), "abc");
+
+        // Create constants as input to the script's function
+        ItemStack variableConst1 = createVariableForValue(helper.getLevel(), ValueTypes.STRING, ValueTypeString.ValueString.of("aether:leather_gloves"));
 
         // Insert all variables into the variable store
         positions.variableStore().getInventory().setItem(0, variableScript);


### PR DESCRIPTION
Fixes #68 (regex usage breaking since 1.0.26).

## The bug

Reproduced in a game test on a clean dev environment. The reporter's visible error is only a follow-on symptom:

```
An error occurred when reading the script "filter-drops.js" at disk 0:
java.lang.NoClassDefFoundError: Could not initialize class
com.oracle.truffle.regex.tregex.util.Loggers
```

The actual first failure is:

```
java.lang.IllegalArgumentException: Unknown language or instrument id regex,
known ids: debugger, engine, graal, sandbox
    at com.oracle.truffle.api.TruffleLogger$LoggerCache.getOrCreateLogger(TruffleLogger.java:1058)
    at com.oracle.truffle.api.TruffleLogger.getLogger(TruffleLogger.java:161)
    at com.oracle.truffle.regex.tregex.util.Loggers.<clinit>(Loggers.java:64)
    at com.oracle.truffle.regex.tregex.TRegexCompiler.shouldLogCompilationTime(TRegexCompiler.java:119)
    at com.oracle.truffle.regex.tregex.TRegexCompiler.compile(TRegexCompiler.java:70)
    at com.oracle.truffle.regex.RegexLanguage.createRegexObject(RegexLanguage.java:205)
    ...
    at com.oracle.truffle.js.nodes.access.RegExpLiteralNode.execute(RegExpLiteralNode.java:83)
```

TRegex resolves its static loggers the first time a regex literal is compiled. That lookup validates the `regex` language id against the languages visible from the thread context classloader, which on a server thread is NeoForge's classloader and does not see the packaged Graal jars (note that `js` is missing from the known ids too). Because this happens inside a static initializer, the failure is permanent for the whole JVM session, so every later script using a regex only ever reports the `NoClassDefFoundError` above, no matter how the script is edited.

## Why it started at 1.0.26

Graal 25.0 resolved this id set through `EngineSupport.getLanguageIds()` and cached it on the logger cache (`TruffleLogger$LoggerCache.knownIds`). Since 25.1 it is resolved per call via `EngineSupport.isKnownLoggerId(...)` against `LanguageCache.languages()`, which depends on the current thread context classloader. That matches the report: fine on 1.0.24 (Graal 25.0.x), broken on 1.0.26 (25.2.4).

## The fix

Compile a regex during the existing startup pre-load, so TRegex initializes while the context classloader still points to the Graal fallback classloader, which is where all other Graal initialization already happens.

## Tests

Added `testScriptsDisplayScriptRegex`, which applies a script function containing a regex literal. It fails on master with exactly the reporter's `NoClassDefFoundError`, and passes with this change.

`./gradlew build` and `./gradlew runGameTestServer` both pass on this branch (all 22 game tests).

## master-1.20-lts

Not applicable, for two independent reasons:

- That branch has no `PackagedDependenciesLoader`/`UnsafeHelper`. It ships Graal through `shadowJar` with package relocation, so Graal is on the mod's own classpath and there is no fallback classloader to be blind to. There is also no game test infrastructure there for the regression test.
- It is on `graal_version=25.0.1`, which predates the Graal change described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwXjG9jWXimuecAeHk5oby

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwXjG9jWXimuecAeHk5oby)_